### PR TITLE
Add missing .env.example file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+NEXT_PUBLIC_SUPABASE_URL=your-supabase-url
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
+SUPABASE_SERVICE_ROLE_KEY=your-supabase-service-role-key
+RESEND_API_KEY=your-resend-api-key
+NEXT_PUBLIC_BASE_URL=http://localhost:3000
+POLAR_ACCESS_TOKEN=your-polar-access-token
+POLAR_SUCCESS_URL=http://localhost:3000/success
+POLAR_WEBHOOK_SECRET=your-polar-webhook-secret
+ANALYTICS_AI_SYSTEM_PROMPT=your-analytics-ai-system-prompt
+GROQ_API_KEY=your-groq-api-key
+AI_FORM_SYSTEM_PROMPT=your-ai-form-system-prompt

--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,33 @@
+# =============================================================================
+# SUPABASE CONFIGURATION
+# =============================================================================
 NEXT_PUBLIC_SUPABASE_URL=your-supabase-url
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
 SUPABASE_SERVICE_ROLE_KEY=your-supabase-service-role-key
+
+# =============================================================================
+# EMAIL SERVICE
+# =============================================================================
 RESEND_API_KEY=your-resend-api-key
+
+# =============================================================================
+# APPLICATION URLS
+# =============================================================================
 NEXT_PUBLIC_BASE_URL=http://localhost:3000
+SITE_URL=http://localhost:3000
+
+# =============================================================================
+# PAYMENT INTEGRATION (POLAR)
+# =============================================================================
 POLAR_ACCESS_TOKEN=your-polar-access-token
 POLAR_SUCCESS_URL=http://localhost:3000/success
 POLAR_WEBHOOK_SECRET=your-polar-webhook-secret
-ANALYTICS_AI_SYSTEM_PROMPT=your-analytics-ai-system-prompt
+
+# =============================================================================
+# AI SERVICES
+# =============================================================================
 GROQ_API_KEY=your-groq-api-key
+GROQ_MODEL=fastest
+COHERE_API_KEY=your-cohere-api-key
+ANALYTICS_AI_SYSTEM_PROMPT=your-analytics-ai-system-prompt
 AI_FORM_SYSTEM_PROMPT=your-ai-form-system-prompt

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -62,20 +62,10 @@ The app will be available at `http://localhost:3000` by default.
 
 ### Environment Variables
 
-Create a `.env.local` file in the project root. Use `.env.example` as a template. The following variables are required:
+Create a `.env.local` file in the project root and configure the required environment variables:
 
-```env
-NEXT_PUBLIC_SUPABASE_URL=your-supabase-url
-NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
-SUPABASE_SERVICE_ROLE_KEY=your-supabase-service-role-key
-RESEND_API_KEY=your-resend-api-key
-NEXT_PUBLIC_BASE_URL=http://localhost:3000
-POLAR_ACCESS_TOKEN=your-polar-access-token
-POLAR_SUCCESS_URL=http://localhost:3000/success
-POLAR_WEBHOOK_SECRET=your-polar-webhook-secret
-ANALYTICS_AI_SYSTEM_PROMPT=your-analytics-ai-system-prompt
-GROQ_API_KEY=your-groq-api-key
-AI_FORM_SYSTEM_PROMPT=your-ai-form-system-prompt
+```bash
+cp .env.example .env.local
 ```
 
 ### Code Quality


### PR DESCRIPTION
## Problem
README referenced `.env.example` for setup instructions, but the file didn't exist in the repository.

## Solution
Added `.env.example` with all required environment variables
Updated `.gitignore` to track `.env.example` while keeping other env files private