### PR TITLE
Remove lifetime plan color animation from pricing

### DIFF
--- a/src/components/home/pricing/client.tsx
+++ b/src/components/home/pricing/client.tsx
@@ -6,7 +6,6 @@ import {
 	Code2,
 	Database,
 	Gauge,
-	HelpCircle,
 	Infinity,
 	ListChecks,
 	ShieldBan,
@@ -16,11 +15,6 @@ import Link from "next/link";
 import React, { useEffect, useRef, useState } from "react";
 import { Badge } from "@/components/ui";
 import { Button } from "@/components/ui/button";
-import {
-	Tooltip,
-	TooltipContent,
-	TooltipTrigger,
-} from "@/components/ui/tooltip";
 import { useAuth } from "@/hooks/use-auth";
 import { usePremiumStatus } from "@/hooks/use-premium-status";
 
@@ -182,57 +176,9 @@ export default function PricingClient({ products }: PricingClientProps) {
 				</header>
 				<div className="mb-6 flex flex-col gap-2">
 					<div className="flex items-baseline gap-2">
-						{plan.key === "lifetime" ? (
-							<>
-								<span className="font-semibold text-xl text-foreground tracking-tighter line-through opacity-50">
-									{plan.price}
-								</span>
-								<span
-									className="font-semibold text-4xl tracking-tighter"
-									style={{
-										background: "linear-gradient(90deg, red, #ff3cac)",
-										backgroundClip: "text",
-										WebkitBackgroundClip: "text",
-										color: "transparent",
-										WebkitTextFillColor: "transparent",
-										animation: "blue-purple-morph 5s linear infinite",
-									}}
-								>
-									$50
-								</span>
-								<style jsx>{`
-									@keyframes blue-purple-morph {
-										0% {
-											filter: hue-rotate(0deg);
-										}
-										100% {
-											filter: hue-rotate(360deg);
-										}
-									}
-								`}</style>
-								<Tooltip>
-									<TooltipTrigger asChild>
-										<button
-											aria-label="Discount code information"
-											className="flex items-center cursor-help"
-											type="button"
-										>
-											<HelpCircle
-												aria-hidden="true"
-												className="size-4 text-muted-foreground transition-colors hover:text-foreground"
-											/>
-										</button>
-									</TooltipTrigger>
-									<TooltipContent side="top">
-										<p>Use code BLACKFRIDAY to get 49% off</p>
-									</TooltipContent>
-								</Tooltip>
-							</>
-						) : (
-							<span className="font-semibold text-3xl text-foreground tracking-tighter">
-								{plan.price}
-							</span>
-						)}
+						<span className="font-semibold text-3xl text-foreground tracking-tighter">
+							{plan.price}
+						</span>
 						{plan.period ? (
 							<span className="text-muted-foreground">{plan.period}</span>
 						) : null}


### PR DESCRIPTION
Remove color animation and discount tooltip from lifetime plan pricing to simplify its display and align with other plans.

---
<a href="https://cursor.com/background-agent?bcId=bc-4e4ceabd-5835-42c5-8489-96dac653d83d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4e4ceabd-5835-42c5-8489-96dac653d83d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

