### PR TITLE
feat(form): add dual-handle slider mode

### DIFF
--- a/src/components/form-builder/field-settings-panel/components/field-settings/slider-field-settings.tsx
+++ b/src/components/form-builder/field-settings-panel/components/field-settings/slider-field-settings.tsx
@@ -1,12 +1,34 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import {
+	normalizeSliderSettings,
+	type SliderMode,
+} from "@/lib/fields/slider-utils";
 import type { FieldSettingsProps } from "./types";
 
 export function SliderFieldSettings({
 	field,
 	onUpdateSettings,
 }: FieldSettingsProps) {
+	const sliderSettings = normalizeSliderSettings(field.settings);
+
+	const updateSliderSettings = (updates: Partial<typeof sliderSettings>) => {
+		const nextSettings = normalizeSliderSettings({
+			...field.settings,
+			...updates,
+		});
+
+		onUpdateSettings(nextSettings);
+	};
+
 	return (
 		<Card className="gap-2 p-4 shadow-none">
 			<CardHeader className="p-0">
@@ -15,6 +37,28 @@ export function SliderFieldSettings({
 				</CardTitle>
 			</CardHeader>
 			<CardContent className="flex flex-col gap-4 p-0">
+				<div className="flex flex-col gap-2">
+					<Label className="font-medium text-sm" htmlFor="slider-mode">
+						Slider Mode
+					</Label>
+					<Select
+						onValueChange={(value) =>
+							updateSliderSettings({ sliderMode: value as SliderMode })
+						}
+						value={sliderSettings.sliderMode}
+					>
+						<SelectTrigger aria-describedby="slider-mode-help" id="slider-mode">
+							<SelectValue placeholder="Select slider mode" />
+						</SelectTrigger>
+						<SelectContent>
+							<SelectItem value="single">Single value</SelectItem>
+							<SelectItem value="range">Range (min + max)</SelectItem>
+						</SelectContent>
+					</Select>
+					<p className="text-muted-foreground text-xs" id="slider-mode-help">
+						Choose one value or let users pick a minimum and maximum
+					</p>
+				</div>
 				<div className="flex flex-col gap-2">
 					<Label className="font-medium text-sm" htmlFor="slider-min">
 						Minimum Value
@@ -25,8 +69,8 @@ export function SliderFieldSettings({
 						id="slider-min"
 						name="slider-min"
 						onChange={(e) =>
-							onUpdateSettings({
-								min: Number.parseInt(e.target.value) || 0,
+							updateSliderSettings({
+								min: Number.parseFloat(e.target.value) || 0,
 							})
 						}
 						onKeyDown={(e) => {
@@ -35,7 +79,7 @@ export function SliderFieldSettings({
 							}
 						}}
 						type="number"
-						value={field.settings?.min || 0}
+						value={sliderSettings.min}
 					/>
 					<p className="text-muted-foreground text-xs" id="slider-min-help">
 						Minimum value for the slider
@@ -51,8 +95,8 @@ export function SliderFieldSettings({
 						id="slider-max"
 						name="slider-max"
 						onChange={(e) =>
-							onUpdateSettings({
-								max: Number.parseInt(e.target.value) || 100,
+							updateSliderSettings({
+								max: Number.parseFloat(e.target.value) || 100,
 							})
 						}
 						onKeyDown={(e) => {
@@ -61,7 +105,7 @@ export function SliderFieldSettings({
 							}
 						}}
 						type="number"
-						value={field.settings?.max || 100}
+						value={sliderSettings.max}
 					/>
 					<p className="text-muted-foreground text-xs" id="slider-max-help">
 						Maximum value for the slider
@@ -78,8 +122,8 @@ export function SliderFieldSettings({
 						min="1"
 						name="slider-step"
 						onChange={(e) =>
-							onUpdateSettings({
-								step: Number.parseInt(e.target.value) || 1,
+							updateSliderSettings({
+								step: Number.parseFloat(e.target.value) || 1,
 							})
 						}
 						onKeyDown={(e) => {
@@ -88,38 +132,101 @@ export function SliderFieldSettings({
 							}
 						}}
 						type="number"
-						value={field.settings?.step || 1}
+						value={sliderSettings.step}
 					/>
 					<p className="text-muted-foreground text-xs" id="slider-step-help">
 						Increment/decrement step size for the slider
 					</p>
 				</div>
-				<div className="flex flex-col gap-2">
-					<Label className="font-medium text-sm" htmlFor="slider-default">
-						Default Value
-					</Label>
-					<Input
-						aria-describedby="slider-default-help"
-						autoComplete="off"
-						id="slider-default"
-						name="slider-default"
-						onChange={(e) =>
-							onUpdateSettings({
-								defaultValue: Number.parseInt(e.target.value) || 50,
-							})
-						}
-						onKeyDown={(e) => {
-							if (e.key === "Escape") {
-								e.currentTarget.blur();
+				{sliderSettings.sliderMode === "range" ? (
+					<>
+						<div className="flex flex-col gap-2">
+							<Label className="font-medium text-sm" htmlFor="slider-default-min">
+								Default Minimum
+							</Label>
+							<Input
+								aria-describedby="slider-default-min-help"
+								autoComplete="off"
+								id="slider-default-min"
+								name="slider-default-min"
+								onChange={(e) =>
+									updateSliderSettings({
+										defaultRangeMin: Number.parseFloat(e.target.value) || 0,
+									})
+								}
+								onKeyDown={(e) => {
+									if (e.key === "Escape") {
+										e.currentTarget.blur();
+									}
+								}}
+								type="number"
+								value={sliderSettings.defaultRangeMin}
+							/>
+							<p
+								className="text-muted-foreground text-xs"
+								id="slider-default-min-help"
+							>
+								Pre-filled minimum value when the form loads
+							</p>
+						</div>
+						<div className="flex flex-col gap-2">
+							<Label className="font-medium text-sm" htmlFor="slider-default-max">
+								Default Maximum
+							</Label>
+							<Input
+								aria-describedby="slider-default-max-help"
+								autoComplete="off"
+								id="slider-default-max"
+								name="slider-default-max"
+								onChange={(e) =>
+									updateSliderSettings({
+										defaultRangeMax: Number.parseFloat(e.target.value) || 0,
+									})
+								}
+								onKeyDown={(e) => {
+									if (e.key === "Escape") {
+										e.currentTarget.blur();
+									}
+								}}
+								type="number"
+								value={sliderSettings.defaultRangeMax}
+							/>
+							<p
+								className="text-muted-foreground text-xs"
+								id="slider-default-max-help"
+							>
+								Pre-filled maximum value when the form loads
+							</p>
+						</div>
+					</>
+				) : (
+					<div className="flex flex-col gap-2">
+						<Label className="font-medium text-sm" htmlFor="slider-default">
+							Default Value
+						</Label>
+						<Input
+							aria-describedby="slider-default-help"
+							autoComplete="off"
+							id="slider-default"
+							name="slider-default"
+							onChange={(e) =>
+								updateSliderSettings({
+									defaultValue: Number.parseFloat(e.target.value) || 50,
+								})
 							}
-						}}
-						type="number"
-						value={field.settings?.defaultValue || 50}
-					/>
-					<p className="text-muted-foreground text-xs" id="slider-default-help">
-						Pre-filled value when the form loads
-					</p>
-				</div>
+							onKeyDown={(e) => {
+								if (e.key === "Escape") {
+									e.currentTarget.blur();
+								}
+							}}
+							type="number"
+							value={sliderSettings.defaultValue}
+						/>
+						<p className="text-muted-foreground text-xs" id="slider-default-help">
+							Pre-filled value when the form loads
+						</p>
+					</div>
+				)}
 			</CardContent>
 		</Card>
 	);

--- a/src/components/form-builder/form-customize/components/layout-customization-section.tsx
+++ b/src/components/form-builder/form-customize/components/layout-customization-section.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Monitor, Ruler } from "lucide-react";
+import { useEffect, useState } from "react";
 import {
 	DEFAULT_FORM_DESIGN,
 	FORM_BORDER_RADIUS_OPTIONS,
@@ -89,8 +90,45 @@ export function LayoutCustomizationSection({
 			Math.max(0, Math.min(value, FORM_BORDER_RADIUS_OPTIONS.length - 1))
 		].value;
 
+	const [widthSliderValue, setWidthSliderValue] = useState<number>(() =>
+		getWidthSliderValue(currentWidth)
+	);
+	const [paddingSliderValue, setPaddingSliderValue] = useState<number>(() =>
+		getPaddingSliderValue(currentPadding)
+	);
+	const [marginSliderValue, setMarginSliderValue] = useState<number>(() =>
+		getMarginSliderValue(currentMargin)
+	);
+	const [borderRadiusSliderValue, setBorderRadiusSliderValue] = useState<number>(
+		() => getBorderRadiusSliderValue(currentBorderRadius)
+	);
+
+	useEffect(() => {
+		setWidthSliderValue(getWidthSliderValue(currentWidth));
+	}, [currentWidth]);
+
+	useEffect(() => {
+		setPaddingSliderValue(getPaddingSliderValue(currentPadding));
+	}, [currentPadding]);
+
+	useEffect(() => {
+		setMarginSliderValue(getMarginSliderValue(currentMargin));
+	}, [currentMargin]);
+
+	useEffect(() => {
+		setBorderRadiusSliderValue(getBorderRadiusSliderValue(currentBorderRadius));
+	}, [currentBorderRadius]);
+
 	const handleBorderRadiusChange = (values: number[]) => {
-		const newRadius = getBorderRadiusFromSlider(values[0]);
+		setBorderRadiusSliderValue(values[0] ?? 0);
+	};
+
+	const handleBorderRadiusCommit = (values: number[]) => {
+		const nextSliderValue = values[0] ?? borderRadiusSliderValue;
+		const newRadius = getBorderRadiusFromSlider(nextSliderValue);
+		if (newRadius === currentBorderRadius) {
+			return;
+		}
 		updateSettings({
 			layout: {
 				...localSettings.layout,
@@ -100,7 +138,15 @@ export function LayoutCustomizationSection({
 	};
 
 	const handleWidthChange = (values: number[]) => {
-		const newWidth = getWidthFromSlider(values[0]);
+		setWidthSliderValue(values[0] ?? 0);
+	};
+
+	const handleWidthCommit = (values: number[]) => {
+		const nextSliderValue = values[0] ?? widthSliderValue;
+		const newWidth = getWidthFromSlider(nextSliderValue);
+		if (newWidth === currentWidth) {
+			return;
+		}
 		updateSettings({
 			layout: {
 				...localSettings.layout,
@@ -119,7 +165,15 @@ export function LayoutCustomizationSection({
 	};
 
 	const handlePaddingChange = (values: number[]) => {
-		const newPadding = getPaddingFromSlider(values[0]);
+		setPaddingSliderValue(values[0] ?? 0);
+	};
+
+	const handlePaddingCommit = (values: number[]) => {
+		const nextSliderValue = values[0] ?? paddingSliderValue;
+		const newPadding = getPaddingFromSlider(nextSliderValue);
+		if (newPadding === currentPadding) {
+			return;
+		}
 		updateSettings({
 			layout: {
 				...localSettings.layout,
@@ -129,7 +183,15 @@ export function LayoutCustomizationSection({
 	};
 
 	const handleMarginChange = (values: number[]) => {
-		const newMargin = getMarginFromSlider(values[0]);
+		setMarginSliderValue(values[0] ?? 0);
+	};
+
+	const handleMarginCommit = (values: number[]) => {
+		const nextSliderValue = values[0] ?? marginSliderValue;
+		const newMargin = getMarginFromSlider(nextSliderValue);
+		if (newMargin === currentMargin) {
+			return;
+		}
 		updateSettings({
 			layout: {
 				...localSettings.layout,
@@ -187,8 +249,9 @@ export function LayoutCustomizationSection({
 									max={FORM_WIDTH_OPTIONS.length - 1}
 									min={0}
 									onValueChange={handleWidthChange}
+									onValueCommitted={handleWidthCommit}
 									step={1}
-									value={[getWidthSliderValue(currentWidth)]}
+									value={[widthSliderValue]}
 								/>
 							</div>
 							{currentWidth === "custom" && (
@@ -206,7 +269,7 @@ export function LayoutCustomizationSection({
 							)}
 							<p className="text-muted-foreground text-xs">
 								{(() => {
-									const idx = getWidthSliderValue(currentWidth);
+									const idx = widthSliderValue;
 									const opt = FORM_WIDTH_OPTIONS[idx];
 									return opt ? `${opt.label} (${opt.description})` : "";
 								})()}
@@ -226,13 +289,14 @@ export function LayoutCustomizationSection({
 									max={FORM_PADDING_OPTIONS.length - 1}
 									min={0}
 									onValueChange={handlePaddingChange}
+									onValueCommitted={handlePaddingCommit}
 									step={1}
-									value={[getPaddingSliderValue(currentPadding)]}
+									value={[paddingSliderValue]}
 								/>
 							</div>
 							<p className="text-muted-foreground text-xs">
 								{(() => {
-									const idx = getPaddingSliderValue(currentPadding);
+									const idx = paddingSliderValue;
 									const opt = FORM_PADDING_OPTIONS[idx];
 									return opt ? `${opt.label} (${opt.description})` : "";
 								})()}
@@ -252,13 +316,14 @@ export function LayoutCustomizationSection({
 									max={FORM_MARGIN_OPTIONS.length - 1}
 									min={0}
 									onValueChange={handleMarginChange}
+									onValueCommitted={handleMarginCommit}
 									step={1}
-									value={[getMarginSliderValue(currentMargin)]}
+									value={[marginSliderValue]}
 								/>
 							</div>
 							<p className="text-muted-foreground text-xs">
 								{(() => {
-									const idx = getMarginSliderValue(currentMargin);
+									const idx = marginSliderValue;
 									const opt = FORM_MARGIN_OPTIONS[idx];
 									return opt ? `${opt.label} (${opt.description})` : "";
 								})()}
@@ -278,13 +343,14 @@ export function LayoutCustomizationSection({
 									max={FORM_BORDER_RADIUS_OPTIONS.length - 1}
 									min={0}
 									onValueChange={handleBorderRadiusChange}
+									onValueCommitted={handleBorderRadiusCommit}
 									step={1}
-									value={[getBorderRadiusSliderValue(currentBorderRadius)]}
+									value={[borderRadiusSliderValue]}
 								/>
 							</div>
 							<p className="text-muted-foreground text-xs">
 								{(() => {
-									const idx = getBorderRadiusSliderValue(currentBorderRadius);
+									const idx = borderRadiusSliderValue;
 									const opt = FORM_BORDER_RADIUS_OPTIONS[idx];
 									return opt ? `${opt.label} (${opt.description})` : "";
 								})()}

--- a/src/components/form-builder/form-customize/components/typography-customization-section.tsx
+++ b/src/components/form-builder/form-customize/components/typography-customization-section.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Type } from "lucide-react";
+import { useEffect, useState } from "react";
 import {
 	FONT_SIZE_OPTIONS,
 	FONT_WEIGHT_OPTIONS,
@@ -53,13 +54,26 @@ export function TypographyCustomizationSection({
 			Math.max(0, Math.min(value, FONT_WEIGHT_OPTIONS.length - 1))
 		].value;
 
-	const handleFontFamilyChange = (value: string) => {
-		console.log("Font family changed to:", value);
+	const [fontSizeSliderValue, setFontSizeSliderValue] = useState<number>(() =>
+		getFontSizeSliderValue(fontSize)
+	);
+	const [fontWeightSliderValue, setFontWeightSliderValue] = useState<number>(
+		() => getFontWeightSliderValue(fontWeight)
+	);
 
+	useEffect(() => {
+		setFontSizeSliderValue(getFontSizeSliderValue(fontSize));
+	}, [fontSize]);
+
+	useEffect(() => {
+		setFontWeightSliderValue(getFontWeightSliderValue(fontWeight));
+	}, [fontWeight]);
+
+	const handleFontFamilyChange = (value: string) => {
 		if (typeof window !== "undefined") {
-			loadGoogleFont(value)
-				.then(() => console.log("Font loaded successfully:", value))
-				.catch((error) => console.error("Failed to load font:", value, error));
+			loadGoogleFont(value).catch((error) =>
+				console.error("Failed to load font:", value, error)
+			);
 		}
 
 		updateSettings({
@@ -71,7 +85,15 @@ export function TypographyCustomizationSection({
 	};
 
 	const handleFontSizeChange = (values: number[]) => {
-		const newSize = getFontSizeFromSlider(values[0]);
+		setFontSizeSliderValue(values[0] ?? 0);
+	};
+
+	const handleFontSizeCommit = (values: number[]) => {
+		const nextSliderValue = values[0] ?? fontSizeSliderValue;
+		const newSize = getFontSizeFromSlider(nextSliderValue);
+		if (newSize === fontSize) {
+			return;
+		}
 		updateSettings({
 			typography: {
 				...localSettings.typography,
@@ -81,7 +103,15 @@ export function TypographyCustomizationSection({
 	};
 
 	const handleFontWeightChange = (values: number[]) => {
-		const newWeight = getFontWeightFromSlider(values[0]);
+		setFontWeightSliderValue(values[0] ?? 0);
+	};
+
+	const handleFontWeightCommit = (values: number[]) => {
+		const nextSliderValue = values[0] ?? fontWeightSliderValue;
+		const newWeight = getFontWeightFromSlider(nextSliderValue);
+		if (newWeight === fontWeight) {
+			return;
+		}
 		updateSettings({
 			typography: {
 				...localSettings.typography,
@@ -153,13 +183,14 @@ export function TypographyCustomizationSection({
 									max={FONT_SIZE_OPTIONS.length - 1}
 									min={0}
 									onValueChange={handleFontSizeChange}
+									onValueCommitted={handleFontSizeCommit}
 									step={1}
-									value={[getFontSizeSliderValue(fontSize)]}
+									value={[fontSizeSliderValue]}
 								/>
 							</div>
 							<p className="text-muted-foreground text-xs">
 								Selected: {(() => {
-									const idx = getFontSizeSliderValue(fontSize);
+									const idx = fontSizeSliderValue;
 									const opt = FONT_SIZE_OPTIONS[idx];
 									return opt ? `${opt.label} (${opt.description})` : "";
 								})()}
@@ -178,13 +209,14 @@ export function TypographyCustomizationSection({
 									max={FONT_WEIGHT_OPTIONS.length - 1}
 									min={0}
 									onValueChange={handleFontWeightChange}
+									onValueCommitted={handleFontWeightCommit}
 									step={1}
-									value={[getFontWeightSliderValue(fontWeight)]}
+									value={[fontWeightSliderValue]}
 								/>
 							</div>
 							<p className="text-muted-foreground text-xs">
 								Selected: {(() => {
-									const idx = getFontWeightSliderValue(fontWeight);
+									const idx = fontWeightSliderValue;
 									const opt = FONT_WEIGHT_OPTIONS[idx];
 									return opt ? `${opt.label} (${opt.description})` : "";
 								})()}

--- a/src/components/form-builder/form-customize/form-customize-page.tsx
+++ b/src/components/form-builder/form-customize/form-customize-page.tsx
@@ -309,7 +309,7 @@ export function FormCustomizePage({ formId, schema }: FormCustomizePageProps) {
 			<div className="flex flex-1 overflow-hidden">
 				{}
 				<div className="hidden w-110 shrink-0 border-r bg-background lg:block">
-					<CustomizationPanel />
+					{CustomizationPanel({})}
 				</div>
 
 				{}
@@ -322,7 +322,7 @@ export function FormCustomizePage({ formId, schema }: FormCustomizePageProps) {
 							</Button>
 						</DrawerTrigger>
 						<DrawerContent className="max-h-[80vh]">
-							<CustomizationPanel isMobile={true} />
+							{CustomizationPanel({ isMobile: true })}
 						</DrawerContent>
 					</Drawer>
 				</div>

--- a/src/components/form-builder/form-field-renderer/components/slider-field.tsx
+++ b/src/components/form-builder/form-field-renderer/components/slider-field.tsx
@@ -1,5 +1,13 @@
+import { useEffect, useMemo, useState } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Slider } from "@/components/ui/slider";
+import { Badge } from "@/components/ui";
+import {
+	isRangeSliderMode,
+	normalizeRangeSliderValue,
+	normalizeSingleSliderValue,
+	normalizeSliderBounds,
+} from "@/lib/fields/slider-utils";
 
 import type { BaseFieldProps } from "../types";
 
@@ -13,40 +21,88 @@ export function SliderField({
 	disabled,
 }: BaseFieldProps) {
 	const errorRingClasses = getErrorRingClasses(error);
+	const isRangeMode = isRangeSliderMode(field.settings);
+	const bounds = normalizeSliderBounds(field.settings);
+	const incomingSingleValue = normalizeSingleSliderValue(field.settings, value);
+	const incomingRangeValue = normalizeRangeSliderValue(field.settings, value);
 
-	const getSliderMinValue = () => field.settings?.min || 0;
+	const incomingUiValue = useMemo(
+		() =>
+			isRangeMode
+				? [incomingRangeValue.min, incomingRangeValue.max]
+				: [incomingSingleValue],
+		[isRangeMode, incomingRangeValue.min, incomingRangeValue.max, incomingSingleValue]
+	);
+	const [uiValue, setUiValue] = useState<number[]>(incomingUiValue);
 
-	const getSliderMaxValue = () => field.settings?.max || 100;
+	useEffect(() => {
+		setUiValue((previousValue) => {
+			if (
+				previousValue.length === incomingUiValue.length &&
+				previousValue.every((current, index) => current === incomingUiValue[index])
+			) {
+				return previousValue;
+			}
+			return incomingUiValue;
+		});
+	}, [incomingUiValue]);
 
-	const getSliderStepValue = () => field.settings?.step || 1;
-
-	const getSliderDefaultValue = () => field.settings?.defaultValue || 0;
-
-	const getCurrentSliderValue = () => value || getSliderDefaultValue();
+	const normalizedUiSingleValue = normalizeSingleSliderValue(
+		field.settings,
+		uiValue[0]
+	);
+	const normalizedUiRangeValue = normalizeRangeSliderValue(field.settings, uiValue);
 
 	const handleSliderValueChange = (values: number[]) => {
-		onChange(values[0]);
+		if (isRangeMode) {
+			const nextRangeValue = normalizeRangeSliderValue(field.settings, values);
+			setUiValue([nextRangeValue.min, nextRangeValue.max]);
+			onChange(nextRangeValue);
+			return;
+		}
+
+		const nextSingleValue = normalizeSingleSliderValue(field.settings, values[0]);
+		setUiValue([nextSingleValue]);
+		onChange(nextSingleValue);
 	};
 
 	return (
 		<div className="flex flex-col gap-3">
-			<Card className="border-0 p-0 shadow-none">
-				<CardContent className="p-0">
+			<Card className="border-0 bg-transparent p-0 shadow-none">
+				<CardContent className="flex flex-col gap-2 p-0">
 					<Slider
-						aria-valuemax={getSliderMaxValue()}
-						aria-valuemin={getSliderMinValue()}
-						aria-valuenow={getCurrentSliderValue()}
+						aria-valuemax={bounds.max}
+						aria-valuemin={bounds.min}
+						aria-valuenow={isRangeMode ? undefined : normalizedUiSingleValue}
+						aria-valuetext={
+							isRangeMode
+								? `${normalizedUiRangeValue.min} - ${normalizedUiRangeValue.max}`
+								: undefined
+						}
 						className={errorRingClasses}
 						disabled={disabled}
-						max={getSliderMaxValue()}
-						min={getSliderMinValue()}
+						enableRangeDrag={isRangeMode}
+						max={bounds.max}
+						min={bounds.min}
 						onValueChange={handleSliderValueChange}
-						step={getSliderStepValue()}
-						value={[getCurrentSliderValue()]}
+						step={bounds.step}
+						value={
+							isRangeMode
+								? [normalizedUiRangeValue.min, normalizedUiRangeValue.max]
+								: [normalizedUiSingleValue]
+						}
 					/>
-					<p className="text-muted-foreground text-sm">
-						{getCurrentSliderValue()}
-					</p>
+					<div className="flex items-center justify-between text-muted-foreground">
+						<span>{bounds.min}</span>
+						<span>{bounds.max}</span>
+					</div>
+					<div className="flex items-center justify-start">
+						<Badge variant={"outline"}>
+							{isRangeMode
+								? `${normalizedUiRangeValue.min} - ${normalizedUiRangeValue.max}`
+								: `${normalizedUiSingleValue}`}
+						</Badge>
+					</div>
 				</CardContent>
 			</Card>
 		</div>

--- a/src/components/form-builder/form-preview/hooks/useFormPreviewState.ts
+++ b/src/components/form-builder/form-preview/hooks/useFormPreviewState.ts
@@ -1,6 +1,11 @@
 import { useEffect, useRef, useState } from "react";
 
 import type { FormField, FormSchema } from "@/lib/database";
+import {
+	isRangeSliderMode,
+	normalizeRangeSliderValue,
+	normalizeSingleSliderValue,
+} from "@/lib/fields/slider-utils";
 
 const getDefaultValueForField = (field: FormField): any => {
 	switch (field.type) {
@@ -13,7 +18,10 @@ const getDefaultValueForField = (field: FormField): any => {
 		case "select":
 			return "";
 		case "slider":
-			return field.settings?.defaultValue || 50;
+			if (isRangeSliderMode(field.settings)) {
+				return normalizeRangeSliderValue(field.settings);
+			}
+			return normalizeSingleSliderValue(field.settings);
 		case "number":
 			return "";
 		case "text":

--- a/src/components/form-builder/form-settings-modal/sections/api-section.tsx
+++ b/src/components/form-builder/form-settings-modal/sections/api-section.tsx
@@ -28,6 +28,11 @@ import { useAuth } from "@/hooks/use-auth";
 import { toast } from "@/hooks/use-toast";
 import { formsDb } from "@/lib/database";
 import {
+	isRangeSliderMode,
+	normalizeRangeSliderValue,
+	normalizeSingleSliderValue,
+} from "@/lib/fields/slider-utils";
+import {
 	generateFormApiKey,
 	revokeFormApiKey,
 	toggleFormApiEnabled,
@@ -215,7 +220,15 @@ export function ApiSection({
 					sampleData[field.id] = 5;
 					break;
 				case "slider":
-					sampleData[field.id] = 50;
+					if (isRangeSliderMode(field.settings)) {
+						const rangeSample = normalizeRangeSliderValue(field.settings);
+						sampleData[field.id] = {
+							min: rangeSample.min,
+							max: rangeSample.max,
+						};
+					} else {
+						sampleData[field.id] = normalizeSingleSliderValue(field.settings);
+					}
 					break;
 				default:
 					sampleData[field.id] = "Sample value";

--- a/src/components/forms/form-analytics/utils/analytics.ts
+++ b/src/components/forms/form-analytics/utils/analytics.ts
@@ -144,6 +144,16 @@ export const calculateFieldAnalytics = (
 				} else {
 					stringValue = "1 file";
 				}
+			} else if (
+				field.type === "slider" &&
+				response &&
+				typeof response === "object" &&
+				!Array.isArray(response) &&
+				typeof (response as { min?: unknown }).min === "number" &&
+				typeof (response as { max?: unknown }).max === "number"
+			) {
+				const sliderResponse = response as { min: number; max: number };
+				stringValue = `${sliderResponse.min} - ${sliderResponse.max}`;
 			} else {
 				stringValue = Array.isArray(response)
 					? response.join(", ")

--- a/src/components/forms/form-renderer/multi-step/multi-step-form.tsx
+++ b/src/components/forms/form-renderer/multi-step/multi-step-form.tsx
@@ -12,6 +12,10 @@ import { Separator } from "@/components/ui/separator";
 import { SocialMediaIcons } from "@/components/ui/social-media-icons";
 import { useFormStyling } from "@/hooks/use-form-styling";
 import type { FormBlock, FormSchema } from "@/lib/database";
+import {
+	isRangeSliderMode,
+	isSliderRangeValue,
+} from "@/lib/fields/slider-utils";
 import { cn } from "@/lib/utils";
 import { constantTimeCompare } from "@/lib/utils/constant-time-compare";
 import { getFormLayoutClasses } from "@/lib/utils/form-layout";
@@ -465,8 +469,14 @@ export function MultiStepForm({ formId, schema, dir }: MultiStepFormProps) {
 					isEmpty = value.length === 0;
 				} else if (field.type === "radio" || field.settings?.isQuizField) {
 					isEmpty = !value || value === "";
-				} else if (field.type === "rating" || field.type === "slider") {
+				} else if (field.type === "rating") {
 					isEmpty = value === null || value === undefined;
+				} else if (field.type === "slider") {
+					if (isRangeSliderMode(field.settings)) {
+						isEmpty = !isSliderRangeValue(value);
+					} else {
+						isEmpty = value === null || value === undefined;
+					}
 				} else if (field.type === "checkbox") {
 					isEmpty = !Array.isArray(value) || value.length === 0;
 				} else if (field.type === "select") {

--- a/src/components/forms/form-renderer/single-step/hooks/use-single-step-form.ts
+++ b/src/components/forms/form-renderer/single-step/hooks/use-single-step-form.ts
@@ -4,6 +4,11 @@ import { usePrepopulation } from "@/hooks/prepopulation/usePrepopulation";
 import { toast } from "@/hooks/use-toast";
 
 import type { FormField, FormSchema } from "@/lib/database";
+import {
+	isRangeSliderMode,
+	normalizeRangeSliderValue,
+	normalizeSingleSliderValue,
+} from "@/lib/fields/slider-utils";
 
 import { calculateQuizScore, type QuizResult } from "@/lib/quiz/scoring";
 import type { SingleStepFormActions, SingleStepFormState } from "../types";
@@ -24,7 +29,10 @@ const getDefaultValueForField = (field: FormField): any => {
 		case "select":
 			return "";
 		case "slider":
-			return field.settings?.defaultValue || 50;
+			if (isRangeSliderMode(field.settings)) {
+				return normalizeRangeSliderValue(field.settings);
+			}
+			return normalizeSingleSliderValue(field.settings);
 		case "rating":
 			return null;
 		case "number":

--- a/src/components/forms/form-renderer/single-step/utils/form-utils.ts
+++ b/src/components/forms/form-renderer/single-step/utils/form-utils.ts
@@ -1,5 +1,9 @@
 import type { FormField, FormSchema } from "@/lib/database";
 
+import {
+	isRangeSliderMode,
+	isSliderRangeValue,
+} from "@/lib/fields/slider-utils";
 import { safeRegexTest } from "@/lib/utils/safe-regex";
 import { validateEmail } from "@/lib/validation/email-validation";
 
@@ -16,11 +20,17 @@ export const validateSingleStepForm = (
 
 	fields.forEach((field) => {
 		const value = formData[field.id];
+		const isSliderMissingValue =
+			field.type === "slider" &&
+			(isRangeSliderMode(field.settings)
+				? !isSliderRangeValue(value)
+				: value === null || value === undefined);
+		const isMissingRequiredValue =
+			field.type === "slider"
+				? isSliderMissingValue
+				: !value || (Array.isArray(value) && value.length === 0);
 
-		if (
-			field.required &&
-			(!value || (Array.isArray(value) && value.length === 0))
-		) {
+		if (field.required && isMissingRequiredValue) {
 			errors[field.id] =
 				field.validation?.requiredMessage || "This field is required";
 		} else if (field.type === "email" && value) {

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -1,45 +1,193 @@
 "use client";
 
-import * as React from "react";
 import { Slider as SliderPrimitive } from "@base-ui/react/slider";
+import {
+	type PointerEvent as ReactPointerEvent,
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+} from "react";
 
 import { cn } from "@/lib/utils";
 
 interface SliderProps
 	extends Omit<
 		SliderPrimitive.Root.Props,
-		"value" | "defaultValue" | "onValueChange"
+		"value" | "defaultValue" | "onValueChange" | "onValueCommitted"
 	> {
-	value?: number[];
 	defaultValue?: number[];
+	enableRangeDrag?: boolean;
+	onValueCommitted?: (value: number[]) => void;
 	onValueChange?: (value: number[]) => void;
+	value?: number[];
 }
 
 function Slider({
 	className,
 	defaultValue,
+	enableRangeDrag = false,
 	value,
 	onValueChange,
+	onValueCommitted,
 	min = 0,
 	max = 100,
+	orientation = "horizontal",
+	step = 1,
 	...props
 }: SliderProps) {
-	const _values = React.useMemo(
-		() =>
-			Array.isArray(value)
-				? value
-				: Array.isArray(defaultValue)
-					? defaultValue
-					: [min],
-		[value, defaultValue, min]
+	const rootRef = useRef<HTMLDivElement | null>(null);
+	const rangeDragStateRef = useRef<{
+		pointerId: number;
+		span: number;
+		startCoordinate: number;
+		startValues: [number, number];
+	} | null>(null);
+
+	const _values = useMemo(() => {
+		if (Array.isArray(value)) {
+			return value;
+		}
+		if (Array.isArray(defaultValue)) {
+			return defaultValue;
+		}
+		return [min];
+	}, [value, defaultValue, min]);
+
+	const thumbEntries = useMemo(() => {
+		const occurrences = new Map<number, number>();
+		return _values.map((sliderValue) => {
+			const seenCount = (occurrences.get(sliderValue) ?? 0) + 1;
+			occurrences.set(sliderValue, seenCount);
+			return {
+				key: `thumb-${sliderValue}-${seenCount}`,
+			};
+		});
+	}, [_values]);
+
+	const canDragRange =
+		enableRangeDrag && _values.length === 2 && typeof onValueChange === "function";
+
+	const getPointerCoordinate = useCallback(
+		(event: PointerEvent | ReactPointerEvent<Element>) => {
+			if (orientation === "vertical") {
+				return -event.clientY;
+			}
+			return event.clientX;
+		},
+		[orientation]
+	);
+
+	useEffect(() => {
+		if (!canDragRange) {
+			rangeDragStateRef.current = null;
+			return;
+		}
+
+		const handleRangeDragMove = (event: PointerEvent) => {
+			if (!onValueChange) {
+				return;
+			}
+
+			const dragState = rangeDragStateRef.current;
+			if (!dragState || dragState.pointerId !== event.pointerId) {
+				return;
+			}
+
+			if ((event.buttons & 1) !== 1) {
+				rangeDragStateRef.current = null;
+				return;
+			}
+
+			const bounds = rootRef.current?.getBoundingClientRect();
+			if (!bounds) {
+				return;
+			}
+
+			const axisSize =
+				orientation === "vertical" ? bounds.height : bounds.width;
+			if (axisSize <= 0) {
+				return;
+			}
+
+			const valueRange = max - min;
+			if (valueRange <= 0) {
+				return;
+			}
+
+			const normalizedStep = step > 0 ? step : 1;
+			const deltaCoordinate =
+				getPointerCoordinate(event) - dragState.startCoordinate;
+			const rawDelta = (deltaCoordinate / axisSize) * valueRange;
+			const snappedDelta =
+				Math.round(rawDelta / normalizedStep) * normalizedStep;
+
+			const maxStart = Math.max(min, max - dragState.span);
+			const nextMin = Math.max(
+				min,
+				Math.min(maxStart, dragState.startValues[0] + snappedDelta)
+			);
+			const nextMax = Math.min(max, nextMin + dragState.span);
+
+			onValueChange([nextMin, nextMax]);
+		};
+
+		const stopRangeDrag = (event: PointerEvent) => {
+			if (rangeDragStateRef.current?.pointerId === event.pointerId) {
+				rangeDragStateRef.current = null;
+			}
+		};
+		const clearRangeDrag = () => {
+			rangeDragStateRef.current = null;
+		};
+
+		window.addEventListener("pointermove", handleRangeDragMove);
+		window.addEventListener("pointerup", stopRangeDrag);
+		window.addEventListener("pointercancel", stopRangeDrag);
+		window.addEventListener("blur", clearRangeDrag);
+
+		return () => {
+			window.removeEventListener("pointermove", handleRangeDragMove);
+			window.removeEventListener("pointerup", stopRangeDrag);
+			window.removeEventListener("pointercancel", stopRangeDrag);
+			window.removeEventListener("blur", clearRangeDrag);
+		};
+	}, [canDragRange, getPointerCoordinate, max, min, onValueChange, orientation, step]);
+
+	const handleRangeDragStart = useCallback(
+		(event: ReactPointerEvent<HTMLDivElement>) => {
+			if (!(canDragRange && onValueChange) || event.button !== 0) {
+				return;
+			}
+
+			event.preventDefault();
+			event.stopPropagation();
+
+			const first = _values[0];
+			const second = _values[1];
+			const startValues: [number, number] =
+				first <= second ? [first, second] : [second, first];
+
+			rangeDragStateRef.current = {
+				pointerId: event.pointerId,
+				span: startValues[1] - startValues[0],
+				startCoordinate: getPointerCoordinate(event),
+				startValues,
+			};
+		},
+		[_values, canDragRange, getPointerCoordinate, onValueChange]
 	);
 
 	return (
 		<SliderPrimitive.Root
-			className={cn("data-horizontal:w-full data-vertical:h-full", className)}
+			className={cn(
+				"data-[orientation=vertical]:h-full data-[orientation=horizontal]:w-full",
+				className
+			)}
 			data-slot="slider"
 			defaultValue={defaultValue}
-			value={value}
+			max={max}
+			min={min}
 			onValueChange={
 				onValueChange
 					? (nextValue) => {
@@ -47,28 +195,43 @@ function Slider({
 					}
 					: undefined
 			}
-			min={min}
-			max={max}
+			onValueCommitted={
+				onValueCommitted
+					? (nextValue) => {
+						onValueCommitted(
+							Array.isArray(nextValue) ? [...nextValue] : [nextValue]
+						);
+					}
+					: undefined
+			}
+			orientation={orientation}
+			ref={rootRef}
+			step={step}
 			thumbAlignment="edge"
+			value={value}
 			{...props}
 		>
-			<SliderPrimitive.Control className="data-vertical:min-h-40 relative flex w-full touch-none items-center select-none data-disabled:opacity-50 data-vertical:h-full data-vertical:w-auto data-vertical:flex-col">
+			<SliderPrimitive.Control className="relative flex w-full touch-none select-none items-center data-[orientation=vertical]:h-full data-[orientation=vertical]:min-h-40 data-[orientation=vertical]:w-auto data-[orientation=vertical]:flex-col data-disabled:opacity-50">
 				<SliderPrimitive.Track
+					className="relative grow select-none overflow-hidden rounded-full bg-muted data-[orientation=horizontal]:h-1.5 data-[orientation=vertical]:h-full data-[orientation=horizontal]:w-full data-[orientation=vertical]:w-1.5"
 					data-slot="slider-track"
-					className="bg-muted rounded-full data-horizontal:h-1.5 data-horizontal:w-full data-vertical:h-full data-vertical:w-1.5 relative grow overflow-hidden select-none"
 				>
 					<SliderPrimitive.Indicator
+						className={cn(
+							"select-none bg-primary data-[orientation=horizontal]:h-full data-[orientation=vertical]:w-full",
+							canDragRange && "cursor-grab active:cursor-grabbing"
+						)}
 						data-slot="slider-range"
-						className="bg-primary select-none data-horizontal:h-full data-vertical:w-full"
+						onPointerDown={canDragRange ? handleRangeDragStart : undefined}
 					/>
 				</SliderPrimitive.Track>
-					{_values.map((sliderValue) => (
-						<SliderPrimitive.Thumb
-							data-slot="slider-thumb"
-							key={`thumb-${sliderValue}`}
-							className="border-primary ring-ring/50 size-4 rounded-full border bg-white shadow-sm transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden block shrink-0 select-none disabled:pointer-events-none disabled:opacity-50"
-						/>
-					))}
+				{thumbEntries.map(({ key }) => (
+					<SliderPrimitive.Thumb
+						className="size-4 rounded-full border border-primary bg-primary shadow-sm transition-[color,box-shadow] hover:ring-4 hover:ring-primary/30 focus-visible:ring-4 focus-visible:ring-primary/40 focus-visible:outline-hidden block shrink-0 select-none disabled:pointer-events-none disabled:opacity-50"
+						data-slot="slider-thumb"
+						key={key}
+					/>
+				))}
 			</SliderPrimitive.Control>
 		</SliderPrimitive.Root>
 	);

--- a/src/lib/database/database.types.ts
+++ b/src/lib/database/database.types.ts
@@ -500,7 +500,10 @@ export interface FormField {
 		min?: number;
 		max?: number;
 		step?: number;
+		sliderMode?: "single" | "range";
 		defaultValue?: any;
+		defaultRangeMin?: number;
+		defaultRangeMax?: number;
 		placeholder?: string;
 		maxTags?: number;
 		allowDuplicates?: boolean;

--- a/src/lib/fields/field-config.ts
+++ b/src/lib/fields/field-config.ts
@@ -25,16 +25,16 @@ import {
 import type { FormField } from "@/lib/database";
 
 export interface FieldTypeConfig {
-	type: FormField["type"];
-	label: string;
-	description: string;
-	icon: LucideIcon;
+	canBeGrouped?: boolean;
 	category: "input" | "selection" | "media" | "layout" | "advanced";
 	defaultLabel: string;
-	defaultPlaceholder?: string;
 	defaultOptions?: string[];
+	defaultPlaceholder?: string;
 	defaultSettings?: Partial<FormField["settings"]>;
-	canBeGrouped?: boolean;
+	description: string;
+	icon: LucideIcon;
+	label: string;
+	type: FormField["type"];
 }
 
 export const FIELD_TYPE_CONFIGS: FieldTypeConfig[] = [
@@ -162,7 +162,13 @@ export const FIELD_TYPE_CONFIGS: FieldTypeConfig[] = [
 		icon: Sliders,
 		category: "selection",
 		defaultLabel: "Slider Field",
-		defaultSettings: { min: 0, max: 100, step: 1, defaultValue: 50 },
+		defaultSettings: {
+			min: 0,
+			max: 100,
+			step: 1,
+			sliderMode: "single",
+			defaultValue: 50,
+		},
 	},
 	{
 		type: "rating",

--- a/src/lib/fields/slider-utils.ts
+++ b/src/lib/fields/slider-utils.ts
@@ -1,0 +1,147 @@
+import type { FormField } from "@/lib/database";
+
+export type SliderMode = "single" | "range";
+
+export interface SliderRangeValue {
+	max: number;
+	min: number;
+}
+
+interface SliderBounds {
+	max: number;
+	min: number;
+	step: number;
+}
+
+const DEFAULT_MIN = 0;
+const DEFAULT_MAX = 100;
+const DEFAULT_STEP = 1;
+const DEFAULT_SINGLE_VALUE = 50;
+
+const toFiniteNumber = (value: unknown): number | null => {
+	if (typeof value === "number" && Number.isFinite(value)) {
+		return value;
+	}
+
+	if (typeof value === "string" && value.trim() !== "") {
+		const parsed = Number(value);
+		if (Number.isFinite(parsed)) {
+			return parsed;
+		}
+	}
+
+	return null;
+};
+
+const clampToBounds = (value: number, bounds: SliderBounds): number =>
+	Math.min(bounds.max, Math.max(bounds.min, value));
+
+const orderRange = (min: number, max: number): SliderRangeValue =>
+	min <= max ? { min, max } : { min: max, max: min };
+
+export function isRangeSliderMode(
+	settings?: FormField["settings"]
+): settings is FormField["settings"] & { sliderMode: "range" } {
+	return settings?.sliderMode === "range";
+}
+
+export function normalizeSliderBounds(
+	settings?: FormField["settings"]
+): SliderBounds {
+	let min = toFiniteNumber(settings?.min) ?? DEFAULT_MIN;
+	let max = toFiniteNumber(settings?.max) ?? DEFAULT_MAX;
+
+	if (min > max) {
+		[min, max] = [max, min];
+	}
+
+	const rawStep = toFiniteNumber(settings?.step) ?? DEFAULT_STEP;
+	const step = rawStep > 0 ? rawStep : DEFAULT_STEP;
+
+	return { min, max, step };
+}
+
+export function normalizeSingleSliderValue(
+	settings?: FormField["settings"],
+	rawValue?: unknown
+): number {
+	const bounds = normalizeSliderBounds(settings);
+	const fallbackValue = clampToBounds(
+		toFiniteNumber(settings?.defaultValue) ?? DEFAULT_SINGLE_VALUE,
+		bounds
+	);
+	const parsedValue = toFiniteNumber(rawValue);
+
+	return clampToBounds(parsedValue ?? fallbackValue, bounds);
+}
+
+export function isSliderRangeValue(value: unknown): value is SliderRangeValue {
+	if (!(value && typeof value === "object") || Array.isArray(value)) {
+		return false;
+	}
+
+	const candidate = value as { min?: unknown; max?: unknown };
+	return (
+		toFiniteNumber(candidate.min) !== null && toFiniteNumber(candidate.max) !== null
+	);
+}
+
+export function normalizeRangeSliderValue(
+	settings?: FormField["settings"],
+	rawValue?: unknown
+): SliderRangeValue {
+	const bounds = normalizeSliderBounds(settings);
+	const defaultRange = orderRange(
+		clampToBounds(toFiniteNumber(settings?.defaultRangeMin) ?? bounds.min, bounds),
+		clampToBounds(toFiniteNumber(settings?.defaultRangeMax) ?? bounds.max, bounds)
+	);
+
+	if (isSliderRangeValue(rawValue)) {
+		return orderRange(
+			clampToBounds(toFiniteNumber(rawValue.min) ?? defaultRange.min, bounds),
+			clampToBounds(toFiniteNumber(rawValue.max) ?? defaultRange.max, bounds)
+		);
+	}
+
+	if (Array.isArray(rawValue)) {
+		const first = toFiniteNumber(rawValue[0]);
+		const second = toFiniteNumber(rawValue[1]);
+		if (first !== null && second !== null) {
+			return orderRange(clampToBounds(first, bounds), clampToBounds(second, bounds));
+		}
+	}
+
+	const scalarValue = toFiniteNumber(rawValue);
+	if (scalarValue !== null) {
+		const clamped = clampToBounds(scalarValue, bounds);
+		return { min: clamped, max: clamped };
+	}
+
+	return defaultRange;
+}
+
+export function normalizeSliderSettings(
+	settings?: FormField["settings"]
+): {
+	sliderMode: SliderMode;
+	min: number;
+	max: number;
+	step: number;
+	defaultValue: number;
+	defaultRangeMin: number;
+	defaultRangeMax: number;
+} {
+	const bounds = normalizeSliderBounds(settings);
+	const rangeValue = normalizeRangeSliderValue(settings);
+	const singleValue = normalizeSingleSliderValue(settings);
+
+	return {
+		sliderMode: isRangeSliderMode(settings) ? "range" : "single",
+		min: bounds.min,
+		max: bounds.max,
+		step: bounds.step,
+		defaultValue: singleValue,
+		defaultRangeMin: rangeValue.min,
+		defaultRangeMax: rangeValue.max,
+	};
+}


### PR DESCRIPTION
## TL;DR
This adds a new range mode for slider questions so users can select both minimum and maximum values. Single-value slider behavior remains backward compatible and continues to work for existing forms.

## Summary
- add slider mode support (`single`/`range`) in field settings and type contracts
- add shared slider normalization utilities for bounds/defaults/value sanitization
- update slider settings UI to configure range defaults (`defaultRangeMin`/`defaultRangeMax`)
- update slider renderer to support `{ min, max }` values, value badges, and range dragging
- update default initialization and required validation for single-step and multi-step forms
- update API sample generation and analytics formatting for range payloads
- improve customize-page slider interaction by committing on release and stabilizing preview dragging
- cache Google Fonts fetches to reduce repeated `/api/google-fonts` calls during rerenders

## Review focus
- range value normalization and backward compatibility with legacy single slider data
- required validation behavior for range sliders in multi-step and single-step flows
- slider UI behavior: track/indicator coloring, thumb keys, and range-drag interaction
- customize page interaction stability and font picker caching side effects

## Test plan
- [x] `bun run build`
- [x] `bun run check` (repo has pre-existing unrelated lint failures)
- [x] Manual: verify drag behavior on `/form-builder/<id>/customize`
- [x] Manual: verify range slider submissions serialize as `{ min, max }`
